### PR TITLE
Truncate file on Unix pipe finalize

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,5 @@
 ---
-Language:        Cpp
+Language:      Cpp
 BasedOnStyle:  Google
+IncludeBlocksStyle: Preserve
 ...

--- a/src/metal-driver/agent_data_sink_context.cpp
+++ b/src/metal-driver/agent_data_sink_context.cpp
@@ -15,7 +15,7 @@ AgentDataSinkContext::AgentDataSinkContext(std::shared_ptr<OperatorAgent> agent,
                                            std::shared_ptr<Pipeline> pipeline,
                                            bool skipReceivingProcessingRequest)
     : FileDataSinkContext(agent->internalOutputFile().second,
-                          agent->internalOutputFile().first, 0, BufferSize),
+                          agent->internalOutputFile().first, 0, BufferSize, true),
       _agent(agent),
       _pipeline(pipeline),
       _skipReceivingProcessingRequest(skipReceivingProcessingRequest) {}

--- a/src/metal-filesystem-pipeline/include/metal-filesystem-pipeline/file_data_sink_context.hpp
+++ b/src/metal-filesystem-pipeline/include/metal-filesystem-pipeline/file_data_sink_context.hpp
@@ -20,7 +20,7 @@ class METAL_FILESYSTEM_PIPELINE_API FileDataSinkContext
  public:
   explicit FileDataSinkContext(std::shared_ptr<PipelineStorage> filesystem,
                                uint64_t inode_id, uint64_t offset,
-                               uint64_t size);
+                               uint64_t size, bool truncateOnFinalize = false);
 
   void prepareForTotalSize(uint64_t size);
 
@@ -32,6 +32,7 @@ class METAL_FILESYSTEM_PIPELINE_API FileDataSinkContext
   void mapExtents(SnapAction &action, fpga::ExtmapSlot slot, std::vector<mtl_file_extent> &extents);
 
   uint64_t _inode_id;
+  bool _truncateOnFinalize;
   std::vector<mtl_file_extent> _extents;
   std::shared_ptr<PipelineStorage> _filesystem;
   uint64_t _cachedTotalSize;


### PR DESCRIPTION
This fixes a bug where the output file size in the internal filesystem was not truncated after a chunked pipeline run (triggered by Unix pipe expression). 

Since in this case the `FileDataSinkContext` is always extended by an entire chunk (64 MB), it must be truncated once all data has been processed (even if the original file size was larger, which is in line with the shell redirection operator semantics).