### PR TITLE
Drone CI: Build SDK Docker images 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,8 +15,32 @@ steps:
     auto_tag: true
     auto_tag_suffix: webpack
     repo: metalfs/sdk-base
-    dockerfile: docker/sdk-base
-    dry_run: true
+    dockerfile: docker/sdk-base/Dockerfile
+    build_args:
+      - VIVADO_EDITION=webpack
+  when:
+    event:
+    - tag
+
+- name: docker metalfs/sdk
+  image: plugins/docker
+  settings:
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    auto_tag: true
+    auto_tag_suffix: webpack-psl8
+    repo: metalfs/sdk
+    dockerfile: docker/sdk/Dockerfile
+    build_args:
+      - PSL=PSL8
+      - VIVADO_EDITION=webpack
+  when:
+    event:
+    - tag
+  depends_on:
+    - docker metalfs/sdk-base
 
 - name: software-build
   image: metalfs/sdk-base:webpack

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,6 +4,20 @@ type: docker
 name: default
 
 steps:
+
+- name: docker metalfs/sdk-base
+  image: plugins/docker
+  settings:
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    auto_tag: true
+    auto_tag_suffix: webpack
+    repo: metalfs/sdk-base
+    dockerfile: docker/sdk-base
+    dry_run: true
+
 - name: software-build
   image: metalfs/sdk-base:webpack
   commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,19 +5,19 @@ name: default
 
 steps:
 - name: software-build
-  image: metalfs/sdk-base:webpack-psl8
+  image: metalfs/sdk-base:webpack
   commands:
     - mkdir build && cd build && cmake -DOPTION_BUILD_EXAMPLES=ON .. && make -j4
 
 - name: snap-action
-  image: metalfs/sdk-base:webpack-psl8
+  image: metalfs/sdk-base:webpack
   commands:
     - cd example/src
     - npm install --production
     - bash -c "make hw_project"
 
 - name: snap-action-testbench
-  image: metalfs/sdk-base:webpack-psl8
+  image: metalfs/sdk-base:webpack
   commands:
     - cd example/src
     - bash -c "make test_target"
@@ -25,7 +25,7 @@ steps:
     - snap-action
 
 - name: example-test-simulation
-  image: metalfs/sdk-base:webpack-psl8
+  image: metalfs/sdk-base:webpack
   commands:
     - cd example/src
     - bash -c "make model"
@@ -38,21 +38,21 @@ steps:
     - snap-action-testbench
 
 - name: filesystem-test
-  image: metalfs/sdk-base:webpack-psl8
+  image: metalfs/sdk-base:webpack
   commands:
     - cd build && ./metal-filesystem-test
   depends_on:
     - software-build
 
 - name: pipeline-test
-  image: metalfs/sdk-base:webpack-psl8
+  image: metalfs/sdk-base:webpack
   commands:
     - cd build && ./metal-pipeline-test
   depends_on:
     - software-build
 
 # - name: storage-test
-#   image: metalfs/sdk-base:webpack-psl8
+#   image: metalfs/sdk-base:webpack
 #   commands:
 #     - cd build && ./metal_storage_test
 #   depends_on:


### PR DESCRIPTION
Drone now automatically updates the `sdk-base` and `sdk` images on Docker hub on each tagged commit.